### PR TITLE
Hide Card Icon with `hideIcon` Optional Prop

### DIFF
--- a/src/components/CardNumber.tsx
+++ b/src/components/CardNumber.tsx
@@ -37,9 +37,11 @@ const CardNumber: React.FC<FramesFieldProps> = (props) => {
                 }
               }}
             />
-            <View style={styles.schemeIconContainer}>
-              <Image style={styles.scheme} source={state.cardIcon} />
-            </View>
+            {props?.hideIcon ? null : (
+              <View style={styles.schemeIconContainer}>
+                <Image style={styles.scheme} source={state.cardIcon} />
+              </View>
+            )}  
           </View>
         );
       }}


### PR DESCRIPTION
To cater to some users demand of hiding card icons, I believe this optional prop will be very useful. Also, with the issue around incorrect detection of Discover card which is linked to the third-party dependency `creditcard-types`, the proposed `hideIcon` prop will offer temporary clean fix by giving developer the option to not display icon.