### PR TITLE
Fix types

### DIFF
--- a/src/types/types.tsx
+++ b/src/types/types.tsx
@@ -179,7 +179,7 @@ export interface FrameCardTokenizedEvent {
   product_type?: string;
   billing_address?: GatewayBillingAddress;
   phone?: GatewayPhone;
-  name?: GatewayBillingAddress;
+  name?: string;
 }
 
 export interface FrameCardTokenizationFailedEvent {


### PR DESCRIPTION
The `name` field in the `FrameCardTokenizedEvent` used the `billing_address` type, which was wrong. This PR fixes that.