### PR TITLE
Feature: Frames `ref` for `submitCard()`

### DIFF
--- a/src/Frames.tsx
+++ b/src/Frames.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useImperativeHandle } from "react";
 import { View, StyleSheet } from "react-native";
 import { framesReducer } from "./utils/reducer";
 import {
@@ -6,13 +6,14 @@ import {
   FramesProps,
   FramesState,
   FramesDispatch,
+  FramesRef,
 } from "./types/types";
 import { log } from "./utils/logger";
 import { tokenize, formatDataForTokenization } from "./utils/http";
 
 export const FramesContext = React.createContext({} as FramesContextType);
 
-const Frames = (props: FramesProps) => {
+const Frames = React.forwardRef<FramesRef, FramesProps>((props, ref) => {
   // @ts-ignore
   const [state, dispatch]: [FramesState, FramesDispatch] = React.useReducer(
     framesReducer,
@@ -154,6 +155,8 @@ const Frames = (props: FramesProps) => {
     }
   }, [state.validation.card]);
 
+  useImperativeHandle(ref, () => ({ submitCard }));
+
   return (
     <View style={[styles.container, props.style]}>
       <FramesContext.Provider value={{ state, dispatch, submitCard }}>
@@ -161,7 +164,7 @@ const Frames = (props: FramesProps) => {
       </FramesContext.Provider>
     </View>
   );
-};
+});
 
 export default Frames;
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,3 +4,4 @@ export { default as ExpiryDate } from "./components/ExpiryDate";
 export { default as Cvv } from "./components/Cvv";
 export { default as SubmitButton } from "./components/SubmitButton";
 export { default as FramesConsumer } from "./Frames";
+export type { FramesRef } from "./types/types";

--- a/src/types/types.tsx
+++ b/src/types/types.tsx
@@ -96,7 +96,7 @@ export interface FramesProps extends ViewStyle {
   style?: StyleProp<ViewStyle>;
   children: any;
   config: FramesConfig;
-  ref?: FramesRef;
+  ref?: React.Ref<FramesRef>;
   frameValidationChanged?: (e: FrameValidationChangedParams) => void;
   paymentMethodChanged?: (e: PaymentMethodChangeParams) => void;
   cardValidationChanged?: (e: FrameCardValidationChangedEvent) => void;

--- a/src/types/types.tsx
+++ b/src/types/types.tsx
@@ -88,10 +88,15 @@ export interface FrameValidationChangedParams {
   isEmpty: boolean;
 }
 
+export interface FramesRef {
+  submitCard: () => void;
+}
+
 export interface FramesProps extends ViewStyle {
   style?: StyleProp<ViewStyle>;
   children: any;
   config: FramesConfig;
+  ref?: FramesRef;
   frameValidationChanged?: (e: FrameValidationChangedParams) => void;
   paymentMethodChanged?: (e: PaymentMethodChangeParams) => void;
   cardValidationChanged?: (e: FrameCardValidationChangedEvent) => void;


### PR DESCRIPTION
Hey @ioan-ghisoi-cko, @dani-z!
Until now, there was no way to submit Frames form without using your `SubmitButton` as `Frames`'s child. However, this creates an issue if we want to use our own custom button, or to control the form from up the component tree.

I added the ability to pass `ref` to `Frames` wrapper, which exposes `submitCard()` method. This way you can trigger form submission whenever you want.
Please let me know if I can improve anything.

I think this would also solve another user's issue #29.